### PR TITLE
added deployment section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ There is a small test suite to test outgoing links, well formed HTML etc. To run
 bundle exec rake test
 ```
 
+## Deployment
+
+Deployment happens automatically from the `master` branch. Current production site is https://mossleyheritage.org/


### PR DESCRIPTION
Closes #11 

I felt that I could have tucked this into the description but that it is an important enough point to warrant its own section, so not so easily read over and missed
